### PR TITLE
Applied conventions on testing/1.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       - <<: *linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
       - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9
+      - <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class LibtirpcConan(ConanFile):
     url = "https://github.com/bincrafters/conan-libtirpc"
     homepage = "https://sourceforge.net/projects/libtirpc"
     author = "Bincrafters <bincrafters@gmail.com>"
-    license = "BSD"
+    license = "BSD-3-Clause"
     exports = ["LICENSE.md"]
     settings = "os", "arch", "compiler", "build_type"
     options = {


### PR DESCRIPTION
Hello,

`bincrafters-conventions` was executed on the branch testing/1.1.4

Dependencies of cpython